### PR TITLE
Add keepalive period to mysql driver connection, so we don't timeout as aggressively.

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,16 @@ Default:        OS default
 Timeout for establishing connections, aka dial timeout. The value must be a decimal number with a unit suffix (*"ms"*, *"s"*, *"m"*, *"h"*), such as *"30s"*, *"0.5m"* or *"1m30s"*.
 
 
+##### `keepalive`
+
+```
+Type:           decimal number
+Default:        OS default
+```
+
+*Driver* side TCP keepalive period; how often to send a TCP packet to verify that the connection to the server is still open. The value must be a string of decimal numbers, each with optional fraction and a unit suffix ( *"ms"*, *"s"*, *"m"*, *"h"* ), such as *"30s"*, *"0.5m"* or *"1m30s"*.
+
+
 ##### `tls`
 
 ```

--- a/connector.go
+++ b/connector.go
@@ -55,11 +55,14 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 
 	// Enable TCP Keepalives on TCP connections
 	if tc, ok := mc.netConn.(*net.TCPConn); ok {
-		if err := tc.SetKeepAlive(true); err != nil {
-			// Don't send COM_QUIT before handshake.
-			mc.netConn.Close()
-			mc.netConn = nil
-			return nil, err
+		if mc.cfg.Keepalive > 0 {
+			if err := tc.SetKeepAlive(true); err != nil {
+				// Don't send COM_QUIT before handshake.
+				mc.netConn.Close()
+				mc.netConn = nil
+				return nil, err
+			}
+			tc.SetKeepAlivePeriod(mc.cfg.Keepalive)
 		}
 	}
 

--- a/dsn.go
+++ b/dsn.go
@@ -48,6 +48,7 @@ type Config struct {
 	TLSConfig        string            // TLS configuration name
 	tls              *tls.Config       // TLS configuration
 	Timeout          time.Duration     // Dial timeout
+	Keepalive        time.Duration     // Keepalive Period
 	ReadTimeout      time.Duration     // I/O read timeout
 	WriteTimeout     time.Duration     // I/O write timeout
 
@@ -503,6 +504,13 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 		// Dial Timeout
 		case "timeout":
 			cfg.Timeout, err = time.ParseDuration(value)
+			if err != nil {
+				return
+			}
+
+		// TCP Keepalive Period
+		case "keepalive":
+			cfg.Keepalive, err = time.ParseDuration(value)
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
Loosely based on https://github.com/go-sql-driver/mysql/commit/c45a03e31e7362e42c0ed74fa6d9f8739d51b10b